### PR TITLE
fix call to formatInt

### DIFF
--- a/src/base/client.zig
+++ b/src/base/client.zig
@@ -152,7 +152,7 @@ pub fn BaseClient(comptime Reader: type, comptime Writer: type) type {
                 },
                 .chunked => {
                     if (data) |payload| {
-                        try std.fmt.formatInt(payload.len, 16, false, .{}, self.writer);
+                        try std.fmt.formatInt(payload.len, 16, .lower, .{}, self.writer);
                         try self.writer.writeAll("\r\n");
                         try self.writer.writeAll(payload);
                         try self.writer.writeAll("\r\n");


### PR DESCRIPTION
Since https://github.com/ziglang/zig/commit/916b645fc1a17f46bab35b54832e037fcf2ab92b the API of `formatInt` changed.

Right now with zig master `zig build test` fails with:
```
./src/base/client.zig:155:64: error: expected type 'std.fmt.Case', found 'bool'
                        try std.fmt.formatInt(payload.len, 16, false, .{}, self.writer);
                                                               ^
/home/vincent/dev/devtools/zig/lib/std/fmt.zig:727:18: note: std.fmt.Case declared here
pub const Case = enum { lower, upper };
                 ^
./src/base/client.zig:155:46: note: referenced here
                        try std.fmt.formatInt(payload.len, 16, false, .{}, self.writer);
                                             ^
The following command exited with error code 1:
/home/vincent/dev/devtools/zig/build/zig test /home/vincent/dev/stuff/hzzp/src/main.zig --cache-dir /home/vincent/dev/stuff/hzzp/zig-cache --global-cache-dir /home/vincent/.cache/zig --name test
error: the following build command failed with exit code 1:
/home/vincent/dev/stuff/hzzp/zig-cache/o/7225baaa7eb8ae3df3b3b050a7bb625b/build /home/vincent/dev/devtools/zig/build/zig /home/vincent/dev/stuff/hzzp /home/vincent/dev/stuff/hzzp/zig-cache /home/vincent/.cache/zig test
```