### PR TITLE
Build system changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
           version: master
 
       - name: Test
-        run: zig build test -Demit_docs
+        run: zig build test -Demit-docs
 
       - name: Publish
         if: success()

--- a/build.zig
+++ b/build.zig
@@ -5,9 +5,10 @@ pub fn build(b: *std.Build) void {
         .root_source_file = .{ .path = "src/main.zig" },
         .optimize = b.standardOptimizeOption(.{}),
     });
+    const run_tests = b.addRunArtifact(lib_tests);
 
     const tests = b.step("test", "Run all library tests");
-    tests.dependOn(&lib_tests.step);
+    tests.dependOn(&run_tests.step);
 
     const docs = b.option(bool, "emit_docs", "Build library documentation") orelse false;
 


### PR DESCRIPTION
- To be usable from the Zig package fetcher, `hzzp` needs to use `b.addModule()`.
- As of a recent Zig update, the `.test` `CompileStep` kind now compiles the test runner rather than executing it. To run it instead, it first needs to be added as a run artifact through `b.addRunArtifact`, the result of which is used as a dependency for the top level `test` step.